### PR TITLE
Feature/upgrade go in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Vault plugin
-FROM golang:1.19 as builder
+FROM golang:1.21 as builder
 
 ARG PLUGIN_NAME=vault-plugin-database-couchbasecapella
 ARG PLUGIN_DIR=/vault/plugins/
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o ${PLUGIN_DIR}/${PLUGIN_NAME} "./cmd/cou
 RUN shasum -a 256 "${PLUGIN_DIR}/${PLUGIN_NAME}" | cut -d " " -f1 > ${PLUGIN_DIR}/${PLUGIN_NAME}.sha256
 
 # Stage 2: Add the plugin to the Vault image
-FROM hashicorp/vault:1.14
+FROM hashicorp/vault:1.15
 
 ARG PLUGIN_NAME=vault-plugin-database-couchbasecapella
 ARG PLUGIN_DIR=/vault/plugins/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Build the Vault plugin
 FROM golang:1.21 as builder
 
-ARG PLUGIN_NAME=vault-plugin-database-couchbasecapella
+ARG PLUGIN_NAME=couchbasecapella-database-plugin
 ARG PLUGIN_DIR=/vault/plugins/
 
 # Install Git
@@ -21,8 +21,8 @@ RUN shasum -a 256 "${PLUGIN_DIR}/${PLUGIN_NAME}" | cut -d " " -f1 > ${PLUGIN_DIR
 # Stage 2: Add the plugin to the Vault image
 FROM hashicorp/vault:1.15
 
-ARG PLUGIN_NAME=vault-plugin-database-couchbasecapella
-ARG PLUGIN_DIR=/vault/plugins/
+ARG PLUGIN_NAME=couchbasecapella-database-plugin
+ARG PLUGIN_DIR=/vault/plugins
 
 ENV PLUGIN_NAME=$PLUGIN_NAME
 ENV PLUGIN_DIR=$PLUGIN_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.21 as builder
 
 ARG PLUGIN_NAME=couchbasecapella-database-plugin
-ARG PLUGIN_DIR=/vault/plugins/
+ARG PLUGIN_DIR=/vault/plugins
 
 # Install Git
 RUN apt-get update && \


### PR DESCRIPTION

- As go 1.19 is obsolete, I upgraded go to 1.21
- I also upgraded vault to 1.15
- changed plugin naming inside the Dockerfile to be the same as the one used when compiling it outside of docker.
