### PR TITLE
Fix authentication no longer working

### DIFF
--- a/httputils.go
+++ b/httputils.go
@@ -212,9 +212,8 @@ func (c *CapellaClient) sendRequest(method string, url string, payload string) (
 		fmt.Printf("error=%v", err)
 		return nil, err
 	}
-	authToken := "Bearer " + base64.StdEncoding.EncodeToString([]byte(c.access+":"+c.secret))
 
-	req.Header.Set("Authorization", authToken)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secret))
 	//req.Header.Set("X-forwarded-for", clientIP)
 	if req.Method == http.MethodPost || req.Method == http.MethodPut {
 		if strings.Contains(url, "?") {


### PR DESCRIPTION
Change authorization header to API key secret, only. 

This fixes the following error message:

```
{"code":1001,"hint":"The request is unauthorized. Please ensure you have provided appropriate credentials in the request header. Please make sure the client IP that is trying to access the resource using the API key is in the API key allowlist.","httpStatusCode":401,"message":"Unauthorized"}
```
