### PR TITLE
fix the issue that fails to rotate the API credential

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -35,7 +35,7 @@ The multi-stage docker container first builds the plugin. It also generates the 
 */vault/vault-plugin-database-couchbasecapella.sha256*
 
 ```bash
-docker exec -it "couchbase_vault" /bin/ash -c "SHA256=\$(cat /vault/vault-plugin-database-couchbasecapella.sha256) && vault login password && vault write sys/plugins/catalog/database/vault-plugin-database-couchbasecapella sha256=\$SHA256 command=vault-plugin-database-couchbasecapella"
+docker exec -it "couchbase_vault" /bin/ash -c "SHA256=\$(cat /vault/couchbasecapella-database-plugin.sha256) && vault login password && vault write sys/plugins/catalog/database/couchbasecapella-database-plugin sha256=\$SHA256 command=couchbasecapella-database-plugin"
 ```
 
 You can check if the plugin was registered by listing the installed plugins with the following command
@@ -57,10 +57,10 @@ docker exec -it "couchbase_vault" /bin/ash -c "vault login password && vault wri
 ### Create database config
 
 You can use the following command to create a database config that sets up the connection to your Capella cluster.
-Make sure to replace the variables.
+Make sure to replace the variables. Please keep in mind the Capella secret you download is base64 encoded. You need to decode it and grab the username and password from that secret. They are separated by :
 
 ```bash
-docker exec -it "couchbase_vault" /bin/ash -c 'vault login password && vault write database/config/vault-plugin-database-couchbasecapella plugin_name="vault-plugin-database-couchbasecapella" cloud_api_base_url="https://cloudapi.cloud.couchbase.com/v4" organization_id="$your_capella_organization_id" project_id="$your_capella_project_id" cluster_id="$your_capella_cluster_id" username="$your_capella_access_key_name" password="$your_capella_access_key_secret" password_policy="couchbasecapella" allowed_roles="*"'
+docker exec -it "couchbase_vault" /bin/ash -c 'vault login password && vault write database/config/couchbasecapella-database-plugin plugin_name="couchbasecapella-database-plugin" cloud_api_base_url="https://cloudapi.cloud.couchbase.com/v4" organization_id="$your_capella_organization_id" project_id="$your_capella_project_id" cluster_id="$your_capella_cluster_id" username="$your_capella_access_key_name" password="$your_capella_access_key_secret" password_policy="couchbasecapella" allowed_roles="*"'
 ```
 > Please note: it uses the password policy we registered before
 
@@ -69,12 +69,12 @@ docker exec -it "couchbase_vault" /bin/ash -c 'vault login password && vault wri
 The plugin supports rotating the root credentials that was used to initialize the database config
 
 ```bash
-docker exec -it "couchbase_vault" /bin/ash -c "vault login password && vault write -force database/rotate-root/vault-plugin-database-couchbasecapella"
+docker exec -it "couchbase_vault" /bin/ash -c "vault login password && vault write -force database/rotate-root/couchbasecapella-database-plugin"
 ```
 ### Create a dynamic role
 
 ```bash
-docker exec -it "couchbase_vault" /bin/ash -c 'vault login password && vault write database/roles/dynamicrole1 db_name="vault-plugin-database-couchbasecapella" creation_statements='\''{"access": [ { "privileges": [ "data_reader", "data_writer" ], "resources": { "buckets": [ { "name": "vault-bucket-1", "scopes": [ { "name": "vault-bucket-1-scope-1", "collections": [ "*" ] } ] } ] } } ]}'\'' default_ttl="5m" max_ttl="1h"'
+docker exec -it "couchbase_vault" /bin/ash -c 'vault login password && vault write database/roles/dynamicrole1 db_name="couchbasecapella-database-plugin" creation_statements='\''{"access": [ { "privileges": [ "data_reader", "data_writer" ], "resources": { "buckets": [ { "name": "vault-bucket-1", "scopes": [ { "name": "vault-bucket-1-scope-1", "collections": [ "*" ] } ] } ] } } ]}'\'' default_ttl="5m" max_ttl="1h"'
 ```
 
 > Please note: this example assumes you have a bucket called: *vault-bucket-1* and a scope called: *vault-bucket-1-scope-1*

--- a/httputils.go
+++ b/httputils.go
@@ -311,8 +311,8 @@ func CreateCapellaDbCredUser(baseUrl string, cloudAPIclustersEndPoint string, ac
 			return fmt.Errorf("failed during capella user creation, reading response error = %v, ep = %s, user = %v, payload=%v,client=%v",
 				err1, ep, username, obfData, c)
 		}
-		return fmt.Errorf("failed during capella user creation, response = %s, ep = %s, user = %v, payload = %v, access=%s, secret=%s",
-			string(b), ep, username, obfData, accessKey, secretKey)
+		return fmt.Errorf("failed during capella user creation, response = %s, ep = %s, user = %v, payload = %v",
+			string(b), ep, username, obfData)
 	}
 	if err != nil {
 		return err

--- a/httputils.go
+++ b/httputils.go
@@ -302,7 +302,7 @@ func CreateCapellaDbCredUser(baseUrl string, cloudAPIclustersEndPoint string, ac
 
 	ep := c.baseURL + cloudAPIclustersEndPoint + "/users"
 	resp, err := c.sendRequest(http.MethodPost, ep, string(data))
-	if resp != nil && resp.StatusCode != 201 {
+	if resp != nil && resp.StatusCode != http.StatusCreated {
 		defer resp.Body.Close()
 		// obfuscate password in the log
 		obfData := fmt.Sprintf("{\"name\":\"%s\", \"password\":\"[password]\", \"access\":%v}", username, string(adata))
@@ -347,7 +347,7 @@ func UpdateCapellaDbCredUser(baseUrl string, cloudAPIclustersEndPoint string, ac
 		data := fmt.Sprintf("{\"secret\":\"%s\"}", password)
 		c.logger.Info(fmt.Sprintf("%s %s %s", http.MethodPost, ep, data))
 		resp, err := c.sendRequest(http.MethodPost, ep, data)
-		if resp != nil && resp.StatusCode != 201 {
+		if resp != nil && resp.StatusCode != http.StatusOK {
 			return "", fmt.Errorf("failed during capella secret key rotate, response = %v, ep = %s",
 				resp, ep)
 		}
@@ -381,7 +381,7 @@ func DeleteCapellaDbCredUser(baseUrl string, cloudAPIclustersEndPoint string, ac
 	}
 	ep := c.baseURL + cloudAPIclustersEndPoint + "/users/" + userId
 	resp, err := c.sendRequest(http.MethodDelete, ep, "")
-	if resp != nil && resp.StatusCode != 204 {
+	if resp != nil && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("failed during capella user deletion, response = %v, ep = %s",
 			resp, ep)
 	}

--- a/httputils.go
+++ b/httputils.go
@@ -345,7 +345,7 @@ func UpdateCapellaDbCredUser(baseUrl string, cloudAPIclustersEndPoint string, ac
 		apiPathSlices := strings.Split(cloudAPIclustersEndPoint, "/")
 		ep := c.baseURL + "/organizations/" + apiPathSlices[2] + "/apikeys/" + username + "/rotate"
 		data := fmt.Sprintf("{\"secret\":\"%s\"}", password)
-		c.logger.Info(fmt.Sprintf("%s %s %s", http.MethodPost, ep, data))
+		c.logger.Info(fmt.Sprintf("%s %s", http.MethodPost, ep))
 		resp, err := c.sendRequest(http.MethodPost, ep, data)
 		if resp != nil && resp.StatusCode != http.StatusOK {
 			return "", fmt.Errorf("failed during capella secret key rotate, response = %v, ep = %s",


### PR DESCRIPTION
This PR aims to fix the issue where the API Key credential can not be rotated as the response code from the management API is 200 while the plugin was looking for 201